### PR TITLE
feat: 사진에서 대표색 추출

### DIFF
--- a/CareHeim/build.gradle
+++ b/CareHeim/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     implementation 'org.openpnp:opencv:4.7.0-0'
     // A Protocol for Asynchronous Non-Blocking Data Sequence
     implementation 'org.reactivestreams:reactive-streams:1.0.3'
+    // for cloud vision
+    implementation 'org.springframework.cloud:spring-cloud-gcp-starter-vision:1.2.8.RELEASE'
+    implementation platform('com.google.cloud:libraries-bom:26.26.0')
+    implementation 'com.google.cloud:google-cloud-bigquery'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/CareHeim/src/main/java/com/spring/careHeim/config/BaseResponseStatus.java
+++ b/CareHeim/src/main/java/com/spring/careHeim/config/BaseResponseStatus.java
@@ -54,7 +54,8 @@ public enum BaseResponseStatus {
     POST_FAIL_S3(false, 2007, "이미지 저장에 실패했습니다."),
     FAIL_CLOTHE_SEG(false, 2008, "의류 분류에 실패했습니다."),
     LOAD_OBJECT_FAIL(false, 2009, "파일 로드에 실패했습니다."),
-    PARSING_ERROR(false, 2010, "파싱 실패")
+    PARSING_ERROR(false, 2010, "파싱 실패"),
+    FAILED_TO_COLOR(false, 2011, "색상 추출에 실패했습니다.")
     ;
 
 

--- a/CareHeim/src/main/java/com/spring/careHeim/domain/image/ImageService.java
+++ b/CareHeim/src/main/java/com/spring/careHeim/domain/image/ImageService.java
@@ -127,4 +127,31 @@ public class ImageService {
 
         return blocs;
     }
+
+    public List<String> getMainColors(byte[] img) throws BaseException {
+        try {
+            List<Color> colors = detectColors(img);
+            List<ColorBloc> colorBlocs = clustringColor(colors);
+
+            double entPixelFraction = 0;
+
+            for(ColorBloc bloc : colorBlocs) {
+                entPixelFraction += bloc.getPixelFraction();
+            }
+
+            ArrayList<String> mainColors = new ArrayList<>();
+
+            for(ColorBloc bloc : colorBlocs) {
+                if(bloc.getPixelFraction() / entPixelFraction < 0.2) {
+                    continue;
+                }
+
+                String name = bloc.getName();
+                mainColors.add(name);
+            }
+            return mainColors;
+        } catch (IOException e) {
+            throw new BaseException(FAILED_TO_COLOR);
+        }
+    }
 }

--- a/CareHeim/src/main/java/com/spring/careHeim/domain/image/ImageService.java
+++ b/CareHeim/src/main/java/com/spring/careHeim/domain/image/ImageService.java
@@ -98,4 +98,33 @@ public class ImageService {
         }
     }
 
+    public List<ColorBloc> clustringColor(List<Color> colors) {
+        List<ColorBloc> blocs = new ArrayList<>();
+
+        for(Color color : colors) {
+            if(blocs.isEmpty()) {
+                ColorBloc newBloc = new ColorBloc(color);
+                blocs.add(newBloc);
+            } else {
+                boolean flag = true;
+                for(ColorBloc bloc : blocs) {
+                    if(bloc.isSameColor(color.getH(), color.getS(), color.getV())) {
+                        bloc.add(color.getH(), color.getS(), color.getV(),color.getPixelFraction());
+                        flag = false;
+                        break;
+                    }
+                }
+
+                if(flag) {
+                    blocs.add(new ColorBloc(color));
+                }
+            }
+        }
+
+        for(ColorBloc bloc : blocs) {
+            bloc.decideColorName();
+        }
+
+        return blocs;
+    }
 }

--- a/CareHeim/src/main/java/com/spring/careHeim/domain/image/model/Color.java
+++ b/CareHeim/src/main/java/com/spring/careHeim/domain/image/model/Color.java
@@ -1,0 +1,61 @@
+package com.spring.careHeim.domain.image.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+@Builder
+public class Color {
+    private double H;
+    private double S;
+    private double V;
+    private double pixelFraction;
+    private String name;
+
+    public Color(int[] RGB) {
+        double[] HSV = this.RGBtoHSV(RGB[0], RGB[1], RGB[2]);
+
+        this.H = HSV[0];
+        this.S = HSV[1];
+        this.V = HSV[2];
+    }
+    public double[] RGBtoHSV(int R, int G, int B) {
+        double[] HSV = new double[3];
+
+        double var_R = (double) R / 255, var_G = (double) G / 255, var_B = (double) B / 255;
+
+        double max = Math.max(Math.max(var_R, var_G), var_B);
+        double min = Math.min(Math.min(var_R, var_G), var_B);
+
+        double delta = max - min;
+
+        HSV[2] = max;
+
+        if(delta == 0) {
+            HSV[0] = 0;
+            HSV[1] = 0;
+        } else {
+            HSV[1] = delta / max;
+
+            if(var_R == max) {
+                HSV[0] = ((var_G - var_B) / delta) % 6;
+            } else if(var_G == max) {
+                HSV[0] = (var_B - var_R) / delta + 2;
+            } else {
+                HSV[0] = (var_R - var_G) / delta + 4;
+            }
+
+            HSV[0] *= 60;
+
+            if(HSV[0] < 0)
+                HSV[0] += 360;
+        }
+
+        HSV[1] *= 100;
+        HSV[2] *= 100;
+
+        return HSV;
+    }
+}

--- a/CareHeim/src/main/java/com/spring/careHeim/domain/image/model/ColorBloc.java
+++ b/CareHeim/src/main/java/com/spring/careHeim/domain/image/model/ColorBloc.java
@@ -1,0 +1,104 @@
+package com.spring.careHeim.domain.image.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+@Builder
+public class ColorBloc {
+    private double avgH;
+    private double avgS;
+    private double avgV;
+    private String name;
+    private double pixelFraction;
+
+    public ColorBloc(Color color) {
+        avgH = color.getH();
+        avgS = color.getS();
+        avgV = color.getV();
+        pixelFraction = color.getPixelFraction();
+    }
+
+    public void add(double H, double S, double V, double new_pixel) {
+        this.avgH = calculateAverage(this.avgH, H, new_pixel);
+        this.avgS = calculateAverage(this.avgS, S, new_pixel);
+        this.avgV = calculateAverage(this.avgV, V, new_pixel);
+        this.pixelFraction += new_pixel;
+    }
+
+    public boolean isSameColor(double H, double S, double V) {
+        if(Math.abs(H - this.avgH) <= 15) {
+            if(Math.abs(S - this.avgS) <= 25) {
+                if(Math.abs(V - this.avgV) <= 30) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public double calculateAverage(double avg, double newValue, double new_pixel) {
+        double newAvg = (avg * this.pixelFraction + newValue * new_pixel) / (this.pixelFraction + new_pixel);
+        return newAvg;
+    }
+
+    public void decideColorName() {
+        String name = "";
+
+        if(this.avgV < 20) {
+            name = "검정색";
+        } else if(this.avgS < 10 && this.avgV > 95) {
+            name = "흰색";
+        } else if(this.avgS < 5) {
+            if(this.avgV < 40) {
+                name = "어두운 ";
+            } else if(this.avgV > 85) {
+                name = "밝은";
+            }
+            name += "회색";
+        } else {
+            if(this.avgV > 60) {
+                if(this.avgS < 25) {
+                    name = "매우 옅은 ";
+                } else if(this.avgS < 60){
+                    name = "연한 ";
+                }
+            } else {
+                name = "짙은 ";
+            }
+
+
+            if(avgH < 15 || avgH > 345) { //red
+                if(this.avgS < 70)
+                    name += "분홍색";
+                else
+                    name += "빨강색";
+            } else if (avgH < 45) { // orange
+                name += "주황색";
+            } else if (avgH < 70) { // yellow
+                name += "노란색";
+            } else if (avgH < 160) { // green
+                name += "초록색";
+            } else if (avgH < 205) { // sky blue
+                name += "하늘색";
+            } else if (avgH < 240) { // blue
+                if(this.avgS < 70) {
+                    if(avgH > 230)
+                        name = "연한 보라색";
+                    else
+                        name = "하늘색";
+                } else {
+                    name += "파란색";
+                }
+            } else if (avgH < 285) { // purple
+                name += "보라색";
+            } else { // rose
+                name += "자주색";
+            }
+        }
+
+        this.name = name;
+    }
+}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 사진의 대표색을 추출하는 기능
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- method
  - `detectColors` : google cloud vision을 이용하여 사진에서 대표색 추출
  - `clustringColor` : detectColors 결과에서, 유사 색상들을 하나의 색상으로 취급
  - `getMainColor` : clustringColor 결과에서 가장 메인이 되는 색상들을 선택, 자연어로 변환
